### PR TITLE
Fix for zeros erroneously being written as empty.

### DIFF
--- a/DotNetDBF/Utils.cs
+++ b/DotNetDBF/Utils.cs
@@ -120,7 +120,7 @@ namespace DotNetDBF
             for (int i = 0; i < sizeWholePart; i++)
             {
 
-                format.Append(sizeWholePart+1== sizeWholePart ? "0":"#");
+                format.Append(i+1== sizeWholePart ? "0":"#");
             }
 
             if (sizeDecimalPart > 0)


### PR DESCRIPTION
In Utils.cs inside of NumericFormating...

Changed...

``` cs
for (var i = 0; i < sizeWholePart; i++) {
  format.Append(sizeWholePart + 1 == sizeWholePart ? "0" : "#");
}
```

...to this.

``` cs
for (var i = 0; i < sizeWholePart; i++) {
  format.Append(i + 1 == sizeWholePart ? "0" : "#");
}
```
