### PR TITLE
Added NumberFormatInfo support

### DIFF
--- a/DotNetDBF/DBFBase.cs
+++ b/DotNetDBF/DBFBase.cs
@@ -12,29 +12,36 @@
  ported to C# (DotNetDBF): Jay Tuley <jay+dotnetdbf@tuley.name> 6/28/2007
  
  */
-/**
- Base class for DBFReader and DBFWriter.
- */
+using System.Globalization;
 using System.Text;
 
 namespace DotNetDBF
 {
-    abstract public class DBFBase
+    /// <summary>
+    /// Base class for <see cref="DBFReader"/> and <see cref="DBFWriter"/>.
+    /// </summary>
+    public abstract class DBFBase
     {
         protected Encoding _charEncoding = Encoding.GetEncoding("utf-8");
         protected int _blockSize = 512;
+        protected NumberFormatInfo _numberFormatProvider = NumberFormatInfo.InvariantInfo;
 
         public Encoding CharEncoding
         {
-            set { _charEncoding = value; }
-
             get { return _charEncoding; }
+            set { _charEncoding = value; }
         }
+
         public int BlockSize
         {
-            set { _blockSize = value; }
-
             get { return _blockSize; }
+            set { _blockSize = value; }
+        }
+
+        public NumberFormatInfo NumberFormatProvider
+        {
+            get { return _numberFormatProvider; }
+            set { _numberFormatProvider = value; }
         }
     }
 }

--- a/DotNetDBF/DBFException.cs
+++ b/DotNetDBF/DBFException.cs
@@ -16,6 +16,9 @@ using System.IO;
 
 namespace DotNetDBF
 {
+    /// <summary>
+    ///  Represents exceptions happen in the <see cref="DotNetDBF"/> classes.
+    /// </summary>
     public class DBFException : IOException
     {
         public DBFException() : base()

--- a/DotNetDBF/DBFFieldType.cs
+++ b/DotNetDBF/DBFFieldType.cs
@@ -15,23 +15,26 @@ using System.Data;
 
 namespace DotNetDBF
 {
-    public enum NativeDbType :byte
+    public enum NativeDbType : byte
     {
-        Autoincrement = (byte) 0x2B, //+ in ASCII
-        Timestamp = (byte) 0x40, //@ in ASCII
-        Binary = (byte) 0x42, //B in ASCII
-        Char = (byte) 0x43, //C in ASCII
-        Date = (byte) 0x44, //D in ASCII
-        Float = (byte) 0x46, //F in ASCII
-        Ole = (byte) 0x47, //G in ASCII
-        Long = (byte) 0x49, //I in ASCII
-        Logical = (byte) 0x4C, //L in ASCII
-        Memo = (byte) 0x4D, //M in ASCII
-        Numeric = (byte) 0x4E, //N in ASCII
-        Double = (byte) 0x4F, //O in ASCII
+        Autoincrement = 0x2B, //+ in ASCII
+        Timestamp =     0x40, //@ in ASCII
+        Binary =        0x42, //B in ASCII
+        Char =          0x43, //C in ASCII
+        Date =          0x44, //D in ASCII
+        Float =         0x46, //F in ASCII
+        Ole =           0x47, //G in ASCII
+        Long =          0x49, //I in ASCII
+        Logical =       0x4C, //L in ASCII
+        Memo =          0x4D, //M in ASCII
+        Numeric =       0x4E, //N in ASCII
+        Double =        0x4F, //O in ASCII
     }
 
-    static public class DBFFieldType
+    /// <summary>
+    /// Class for reading the records assuming that the given Stream contains DBF data.
+    /// </summary>
+    public static class DBFFieldType
     {
         public const byte EndOfData = 0x1A; //^Z End of File
         public const byte EndOfField = 0x0D; //End of Field
@@ -40,9 +43,10 @@ namespace DotNetDBF
         public const byte True = 0x54; //T in ascii
         public const byte UnknownByte = 0x3F; //Unknown Bool value
         public const string Unknown = "?"; //Unknown value
-        static public DbType FromNative(NativeDbType aByte)
+
+        public static DbType FromNative(NativeDbType byteValue)
         {
-            switch (aByte)
+            switch (byteValue)
             {
                 case NativeDbType.Char:
                     return DbType.AnsiStringFixedLength;
@@ -58,11 +62,11 @@ namespace DotNetDBF
                     return DbType.AnsiString;
                 default:
                     throw new DBFException(
-                        string.Format("Unsupported Native Type {0}", aByte));
+                        string.Format("Unsupported Native Type {0}", byteValue));
             }
         }
 
-        static public NativeDbType FromDbType(DbType dbType)
+        public static NativeDbType FromDbType(DbType dbType)
         {
             switch (dbType)
             {

--- a/DotNetDBF/DBFHeader.cs
+++ b/DotNetDBF/DBFHeader.cs
@@ -20,26 +20,20 @@ using System.IO;
 
 namespace DotNetDBF
 {
-
-    static public class DBFSigniture
+    public enum DBFSignature : byte
     {
-        public const byte NotSet = 0,
-                          WithMemo = 0x80,
-                          DBase3 = 0x03,
-                          DBase3WithMemo = DBase3 | WithMemo;
-
+        NotSet = 0,
+        WithMemo = 0x80,
+        DBase3 = 0x03,
+        DBase3WithMemo = DBase3 | WithMemo
     }
 
-    [Flags]
-    public enum MemoFlags : byte
-    {
-        
-    }
-
-
+    /// <summary>
+    /// Class for reading the metadata assuming that the given FileStream carries DBF data.
+    /// </summary>
     public class DBFHeader
     {
-
+        #region Fields
         public const byte HeaderRecordTerminator = 0x0D;
 
         private byte _day; /* 3 */
@@ -57,20 +51,19 @@ namespace DotNetDBF
         private int _reserv2; /* 20-23 */
         private int _reserv3; /* 24-27 */
         private short reserv4; /* 30-31 */
-        private byte _signature; /* 0 */
+        private DBFSignature _signature; /* 0 */
         private byte _year; /* 1 */
+        #endregion
 
-        public DBFHeader()
-        {
-            _signature = DBFSigniture.DBase3;
-        }
+        #region Properties
 
-        internal byte Signature
+        internal DBFSignature Signature
         {
             get
             {
                 return _signature;
-            }set
+            }
+            set
             {
                 _signature = value;
             }
@@ -80,22 +73,22 @@ namespace DotNetDBF
         {
             get
             {
-                return (short) (sizeof (byte) +
-                                sizeof (byte) + sizeof (byte) + sizeof (byte) +
-                                sizeof (int) +
-                                sizeof (short) +
-                                sizeof (short) +
-                                sizeof (short) +
-                                sizeof (byte) +
-                                sizeof (byte) +
-                                sizeof (int) +
-                                sizeof (int) +
-                                sizeof (int) +
-                                sizeof (byte) +
-                                sizeof (byte) +
-                                sizeof (short) +
+                return (short)(sizeof(byte) +
+                                sizeof(byte) + sizeof(byte) + sizeof(byte) +
+                                sizeof(int) +
+                                sizeof(short) +
+                                sizeof(short) +
+                                sizeof(short) +
+                                sizeof(byte) +
+                                sizeof(byte) +
+                                sizeof(int) +
+                                sizeof(int) +
+                                sizeof(int) +
+                                sizeof(byte) +
+                                sizeof(byte) +
+                                sizeof(short) +
                                 (DBFField.SIZE * _fieldArray.Length) +
-                                sizeof (byte));
+                                sizeof(byte));
             }
         }
 
@@ -103,63 +96,56 @@ namespace DotNetDBF
         {
             get
             {
-                int tRecordLength = 0;
+                int recordLength = 0;
                 for (int i = 0; i < _fieldArray.Length; i++)
                 {
-                    tRecordLength += _fieldArray[i].FieldLength;
+                    recordLength += _fieldArray[i].FieldLength;
                 }
 
-                return (short)(tRecordLength + 1);
+                return (short)(recordLength + 1);
             }
         }
 
         internal short HeaderLength
         {
-            set { _headerLength = value; }
-
             get { return _headerLength; }
+            set { _headerLength = value; }
         }
 
         internal DBFField[] FieldArray
         {
-            set { _fieldArray = value; }
-
             get { return _fieldArray; }
+            set { _fieldArray = value; }
         }
 
         internal byte Year
         {
-            set { _year = value; }
-
             get { return _year; }
+            set { _year = value; }
         }
 
         internal byte Month
         {
-            set { _month = value; }
-
             get { return _month; }
+            set { _month = value; }
         }
 
         internal byte Day
         {
-            set { _day = value; }
-
             get { return _day; }
+            set { _day = value; }
         }
 
         internal int NumberOfRecords
         {
-            set { _numberOfRecords = value; }
-
             get { return _numberOfRecords; }
+            set { _numberOfRecords = value; }
         }
 
         internal short RecordLength
         {
-            set { _recordLength = value; }
-
             get { return _recordLength; }
+            set { _recordLength = value; }
         }
 
         internal byte LanguageDriver
@@ -167,10 +153,18 @@ namespace DotNetDBF
             get { return _languageDriver; }
             set { _languageDriver = value; }
         }
+        #endregion
+
+        #region Constructors
+        public DBFHeader()
+        {
+            _signature = DBFSignature.DBase3;
+        }
+        #endregion
 
         internal void Read(BinaryReader dataInput)
         {
-            _signature = dataInput.ReadByte(); /* 0 */
+            _signature = (DBFSignature)dataInput.ReadByte(); /* 0 */
             _year = dataInput.ReadByte(); /* 1 */
             _month = dataInput.ReadByte(); /* 2 */
             _day = dataInput.ReadByte(); /* 3 */
@@ -190,26 +184,26 @@ namespace DotNetDBF
             reserv4 = dataInput.ReadInt16(); /* 30-31 */
 
 
-            List<DBFField> v_fields = new List<DBFField>();
+            List<DBFField> fields = new List<DBFField>();
 
             DBFField field = DBFField.CreateField(dataInput); /* 32 each */
             while (field != null)
             {
-                v_fields.Add(field);
+                fields.Add(field);
                 field = DBFField.CreateField(dataInput);
             }
 
-            _fieldArray = v_fields.ToArray();
+            _fieldArray = fields.ToArray();
             //System.out.println( "Number of fields: " + _fieldArray.length);
         }
 
         internal void Write(BinaryWriter dataOutput)
         {
-            dataOutput.Write(_signature); /* 0 */
+            dataOutput.Write((byte)_signature); /* 0 */
             DateTime tNow = DateTime.Now;
-            _year = (byte) (tNow.Year - 1900);
-            _month = (byte) (tNow.Month);
-            _day = (byte) (tNow.Day);
+            _year = (byte)(tNow.Year - 1900);
+            _month = (byte)(tNow.Month);
+            _day = (byte)(tNow.Day);
 
             dataOutput.Write(_year); /* 1 */
             dataOutput.Write(_month); /* 2 */

--- a/DotNetDBF/DBFReader.cs
+++ b/DotNetDBF/DBFReader.cs
@@ -18,61 +18,76 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Linq;
+
 namespace DotNetDBF
 {
+    /// <summary>
+    /// Class for reading the records assuming that the given <see cref="Stream"/> contains DBF data.
+    /// </summary>
     public class DBFReader : DBFBase, IDisposable
     {
+        #region Fields
         private BinaryReader _dataInputStream;
         private DBFHeader _header;
         private string _dataMemoLoc;
 
-        private int[] _selectFields = new int[]{};
-        private int[] _orderedSelectFields = new int[] { };
-        /* Class specific variables */
+        private int[] _selectFields;
+        private List<int> _orderedSelectFields;
         private bool isClosed = true;
+        #endregion
 
-        /**
-		 Initializes a DBFReader object.
-		 
-		 When this constructor returns the object
-		 will have completed reading the hader (meta date) and
-		 header information can be quried there on. And it will
-		 be ready to return the first row.
-		 
-		 @param InputStream where the data is read from.
-		 */
+        #region Properties
 
-
-
-        public void SetSelectFields(params string[] aParams)
+        /// <summary>
+        /// Returns the number of records in the DBF.
+        /// </summary>
+        public int RecordCount
         {
-            _selectFields =
-                aParams.Select(
-                    it =>
-                    Array.FindIndex(_header.FieldArray,
-                                    jt => jt.Name.Equals(it, StringComparison.InvariantCultureIgnoreCase))).ToArray();
-            _orderedSelectFields = _selectFields.OrderBy(it => it).ToArray();
+            get { return _header.NumberOfRecords; }
         }
 
-        public DBFField[] GetSelectFields()
+        /// <summary>
+        /// Returns the array of table fields.
+        /// </summary>
+        public DBFField[] Fields
         {
-            return _selectFields.Any()
-                ? _selectFields.Select(it => _header.FieldArray[it]).ToArray()
-                : _header.FieldArray;
+            get { return _header.FieldArray; }
         }
 
-        public DBFReader(string anIn)
+        public string DataMemoLoc
+        {
+            get
+            {
+                return _dataMemoLoc;
+            }
+            set
+            {
+                _dataMemoLoc = value;
+            }
+        }
+        #endregion
+
+        #region Constructors
+        public DBFReader()
+        {
+            _selectFields = new int[0];
+        }
+
+        /// <summary>
+        /// Initializes new <see cref="DBFReader"/> object.
+        /// <para>
+        /// Table metadata is cached in the header.
+        /// </para>
+        /// </summary>
+        /// <param name="path">File to open.</param>
+        public DBFReader(string path)
+            :this()
         {
             try
             {
-                _dataInputStream = new BinaryReader(
-                    File.Open(anIn,
-                              FileMode.Open,
-                              FileAccess.Read,
-                              FileShare.Read)
-                    );
+                _dataInputStream = new BinaryReader(File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read));
 
-                var dbtPath = Path.ChangeExtension(anIn, "dbt");
+                string dbtPath = Path.ChangeExtension(path, "dbt");
                 if (File.Exists(dbtPath))
                 {
                     _dataMemoLoc = dbtPath;
@@ -93,95 +108,53 @@ namespace DotNetDBF
             }
             catch (IOException ex)
             {
-                throw new DBFException("Failed To Read DBF", ex);
+                throw new DBFException("Failed to read DBF", ex);
             }
         }
 
-        public DBFReader(Stream anIn)
+        /// <summary>
+        /// Initializes new <see cref="DBFReader"/> object.
+        /// <para>
+        /// Table metadata is cached in the header.
+        /// </para>
+        /// </summary>
+        /// <param name="inputStream"><see cref="Stream"/> where the data is read from.</param>
+        public DBFReader(Stream input)
+            :this()
         {
             try
             {
-                _dataInputStream = new BinaryReader(anIn);
+                _dataInputStream = new BinaryReader(input);
                 isClosed = false;
                 _header = new DBFHeader();
                 _header.Read(_dataInputStream);
 
-                /* it might be required to leap to the start of records at times */
-                int t_dataStartIndex = _header.HeaderLength
+                // it might be required to leap to the start of records at times
+                int dataStartIndex = _header.HeaderLength
                                        - (32 + (32 * _header.FieldArray.Length))
                                        - 1;
-                if (t_dataStartIndex > 0)
+                if (dataStartIndex > 0)
                 {
-                    _dataInputStream.ReadBytes((t_dataStartIndex));
+                    _dataInputStream.ReadBytes(dataStartIndex);
                 }
             }
             catch (IOException e)
             {
-                throw new DBFException("Failed To Read DBF", e);
+                throw new DBFException("Failed to read DBF.", e);
             }
         }
-
-        /**
-		 Returns the number of records in the DBF.
-		 */
-
-        public int RecordCount
-        {
-            get { return _header.NumberOfRecords; }
-        }
-
-        /**
-		 Returns the asked Field. In case of an invalid index,
-		 it returns a ArrayIndexOutofboundsException.
-		 
-		 @param index. Index of the field. Index of the first field is zero.
-		 */
-
-        public DBFField[] Fields
-        {
-            get { return _header.FieldArray; }
-        }
+        #endregion
 
         #region IDisposable Members
 
-        /// <summary>Performs application-defined tasks associated with freeing, releasing,
-        /// or resetting unmanaged resources.</summary>
-        /// <filterpriority>2</filterpriority>
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing,
+        /// or resetting unmanaged resources.
+        /// </summary>
+        /// <remarks>filterpriority = 2</remarks>
         public void Dispose()
         {
             Close();
-        }
-
-        #endregion
-
-
-        public string DataMemoLoc
-        {
-            get
-            {
-                return _dataMemoLoc;
-            }set
-            {
-                _dataMemoLoc = value;
-            }
-        }
-
-        public override String ToString()
-        {
-            StringBuilder sb =
-                new StringBuilder(_header.Year + "/" + _header.Month + "/"
-                                  + _header.Day + "\n"
-                                  + "Total records: " + _header.NumberOfRecords +
-                                  "\nHeader length: " + _header.HeaderLength +
-                                  "");
-
-            for (int i = 0; i < _header.FieldArray.Length; i++)
-            {
-                sb.Append(_header.FieldArray[i].Name);
-                sb.Append("\n");
-            }
-
-            return sb.ToString();
         }
 
         public void Close()
@@ -190,26 +163,52 @@ namespace DotNetDBF
             isClosed = true;
         }
 
-        /**
-		 Reads the returns the next row in the DBF stream.
-		 @returns The next row as an Object array. Types of the elements
-		 these arrays follow the convention mentioned in the class description.
-		 */
-        public Object[] NextRecord()
+        #endregion
+
+        public void SetSelectFields(params string[] aParams)
+        {
+            _selectFields = aParams
+                .Select(p => Array.FindIndex(_header.FieldArray, field => field.Name.Equals(p, StringComparison.InvariantCultureIgnoreCase)))
+                .ToArray();
+
+            _orderedSelectFields = _selectFields.OrderBy(it => it).ToList();
+        }
+
+        public DBFField[] GetSelectFields()
+        {
+            return _selectFields.Any()
+                ? _selectFields.Select(s => _header.FieldArray[s]).ToArray()
+                : _header.FieldArray;
+        }
+
+        /// <summary>
+        /// Reads then returns the next row in the DBF stream.
+        /// </summary>
+        /// <returns>
+        /// The next row as an <see cref="Object"/> array. Types of the elements these arrays follow the convention mentioned in the class description.
+        /// </returns>
+        public object[] NextRecord()
         {
             return NextRecord(_selectFields, _orderedSelectFields);
         }
 
-
-        internal Object[] NextRecord(IEnumerable<int> selectIndexes, IList<int> sortedIndexes)
+        /// <summary>
+        /// Reads then returns the next row in the DBF stream. After the last row returns null.
+        /// </summary>
+        /// <param name="selectIndexes"></param>
+        /// <param name="sortedIndexes"></param>
+        /// <returns>The next row as an <see cref="Object"/> array. Types of the elements these arrays follow the convention mentioned in the class description.</returns>
+        internal object[] NextRecord(int[] selectIndexes, IEnumerable<int> sortedIndexes)
         {
             if (isClosed)
             {
                 throw new DBFException("Source is not open");
             }
-            IList<int> tOrderdSelectIndexes = sortedIndexes;
+            List<int> tOrderdSelectIndexes = new List<int>();
+            if (sortedIndexes != null)
+                tOrderdSelectIndexes.AddRange(sortedIndexes);
 
-            var recordObjects = new Object[_header.FieldArray.Length];
+            object[] recordObjects = new object[_header.FieldArray.Length];
 
             try
             {
@@ -245,175 +244,156 @@ namespace DotNetDBF
                         k = tOrderdSelectIndexes[j];
                     j++;
 
-                  
+
                     switch (_header.FieldArray[i].DataType)
                     {
                         case NativeDbType.Char:
+                            {
+                                byte[] b_array = new byte[_header.FieldArray[i].FieldLength];
+                                _dataInputStream.Read(b_array, 0, b_array.Length);
 
-                            var b_array = new byte[
-                                _header.FieldArray[i].FieldLength
-                                ];
-                            _dataInputStream.Read(b_array, 0, b_array.Length);
-
-                            recordObjects[i] = CharEncoding.GetString(b_array).TrimEnd();
-                            break;
-
+                                recordObjects[i] = CharEncoding.GetString(b_array).TrimEnd();
+                                break;
+                            }
                         case NativeDbType.Date:
-
-                            byte[] t_byte_year = new byte[4];
-                            _dataInputStream.Read(t_byte_year,
-                                                 0,
-                                                 t_byte_year.Length);
-
-                            byte[] t_byte_month = new byte[2];
-                            _dataInputStream.Read(t_byte_month,
-                                                 0,
-                                                 t_byte_month.Length);
-
-                            byte[] t_byte_day = new byte[2];
-                            _dataInputStream.Read(t_byte_day,
-                                                 0,
-                                                 t_byte_day.Length);
-
-                            try
                             {
-                                var tYear = CharEncoding.GetString(t_byte_year);
-                                var tMonth = CharEncoding.GetString(t_byte_month);
-                                var tDay = CharEncoding.GetString(t_byte_day);
+                                byte[] yearByte = new byte[4];
+                                byte[] monthByte = new byte[2];
+                                byte[] dayByte = new byte[2];
 
-                                int tIntYear, tIntMonth, tIntDay;
-                                if (Int32.TryParse(tYear, out tIntYear) &&
-                                    Int32.TryParse(tMonth, out tIntMonth) &&
-                                    Int32.TryParse(tDay, out tIntDay))
+                                _dataInputStream.Read(yearByte, 0, yearByte.Length);
+                                _dataInputStream.Read(monthByte, 0, monthByte.Length);
+                                _dataInputStream.Read(dayByte, 0, dayByte.Length);
+
+                                try
                                 {
-                                    recordObjects[i] = new DateTime(
-                                        tIntYear,
-                                        tIntMonth,
-                                        tIntDay);
+                                    string yearString = CharEncoding.GetString(yearByte);
+                                    string monthString = CharEncoding.GetString(monthByte);
+                                    string dayString = CharEncoding.GetString(dayByte);
+
+                                    int year, month, day;
+                                    if (int.TryParse(yearString, out year) &&
+                                        int.TryParse(monthString, out month) &&
+                                        int.TryParse(dayString, out day))
+                                    {
+                                        recordObjects[i] = new DateTime(year, month, day);
+                                    }
+                                    else
+                                    {
+                                        recordObjects[i] = null;
+                                    }
                                 }
-                                else
+                                catch (ArgumentOutOfRangeException)
                                 {
+                                    /* this field may be empty or may have improper value set */
                                     recordObjects[i] = null;
                                 }
-                            }
-                            catch (ArgumentOutOfRangeException)
-                            {
-                                /* this field may be empty or may have improper value set */
-                                recordObjects[i] = null;
-                            }
 
-                            break;
-
+                                break;
+                            }
                         case NativeDbType.Float:
-
-                            try
                             {
-                                byte[] t_float = new byte[
-                                    _header.FieldArray[i].FieldLength
-                                    ];
-                                _dataInputStream.Read(t_float, 0, t_float.Length);
-                                String tParsed = CharEncoding.GetString(t_float);
-                                var tLast = tParsed.Substring(tParsed.Length - 1);
-                                if (tParsed.Length > 0
-                                    && tLast != " "
-                                    && tLast != DBFFieldType.Unknown)
+                                try
                                 {
-                                    recordObjects[i] = Double.Parse(tParsed, NumberStyles.Float | NumberStyles.AllowLeadingWhite);
+                                    byte[] t_float = new byte[_header.FieldArray[i].FieldLength];
+                                    _dataInputStream.Read(t_float, 0, t_float.Length);
+                                    string tParsed = CharEncoding.GetString(t_float);
+                                    string tLast = tParsed.Substring(tParsed.Length - 1);
+                                    if (tParsed.Length > 0
+                                        && tLast != " "
+                                        && tLast != DBFFieldType.Unknown)
+                                    {
+                                        recordObjects[i] = Convert.ToSingle(tParsed, NumberFormatProvider);
+                                    }
+                                    else
+                                    {
+                                        recordObjects[i] = null;
+                                    }
                                 }
-                                else
+                                catch (FormatException e)
                                 {
-                                    recordObjects[i] = null;
+                                    throw new DBFException("Failed to parse Float", e);
                                 }
-                            }
-                            catch (FormatException e)
-                            {
-                                throw new DBFException("Failed to parse Float",
-                                                       e);
-                            }
 
-                            break;
-
+                                break;
+                            }
                         case NativeDbType.Numeric:
-
-                            try
                             {
-                                byte[] t_numeric = new byte[
-                                    _header.FieldArray[i].FieldLength
-                                    ];
-                                _dataInputStream.Read(t_numeric,
-                                                     0,
-                                                     t_numeric.Length);
-                                string tParsed =
-                                    CharEncoding.GetString(t_numeric);
-                                var tLast = tParsed.Substring(tParsed.Length - 1);
-                                if (tParsed.Length > 0
-                                    && tLast != " "
-                                    && tLast != DBFFieldType.Unknown)
+                                try
                                 {
-                                    recordObjects[i] = Decimal.Parse(tParsed, NumberStyles.Float | NumberStyles.AllowLeadingWhite);
+                                    byte[] t_numeric = new byte[_header.FieldArray[i].FieldLength];
+                                    _dataInputStream.Read(t_numeric, 0, t_numeric.Length);
+                                    string cellValue = CharEncoding.GetString(t_numeric);
+                                    string lastChar = cellValue.Substring(cellValue.Length - 1);
+                                    if (cellValue.Length > 0
+                                        && lastChar != " "
+                                        && lastChar != DBFFieldType.Unknown)
+                                    {
+                                        recordObjects[i] = Convert.ToDouble(cellValue, NumberFormatProvider);
+                                    }
+                                    else
+                                    {
+                                        recordObjects[i] = null;
+                                    }
+                                }
+                                catch (FormatException e)
+                                {
+                                    throw new DBFException("Failed to parse number", e);
+                                }
+
+                                break;
+                            }
+                        case NativeDbType.Logical:
+                            {
+                                byte t_logical = _dataInputStream.ReadByte();
+                                //todo find out whats really valid
+                                if (t_logical == 'Y' || t_logical == 't' || t_logical == 'T' || t_logical == 't')
+                                {
+                                    recordObjects[i] = true;
+                                }
+                                else if (t_logical == DBFFieldType.UnknownByte)
+                                {
+                                    recordObjects[i] = DBNull.Value;
                                 }
                                 else
                                 {
-                                    recordObjects[i] = null;
+                                    recordObjects[i] = false;
                                 }
+                                break;
                             }
-                            catch (FormatException e)
-                            {
-                                throw new DBFException(
-                                    "Failed to parse Number", e);
-                            }
-
-                            break;
-
-                        case NativeDbType.Logical:
-
-                            byte t_logical = _dataInputStream.ReadByte();
-                            //todo find out whats really valid
-                            if (t_logical == 'Y' || t_logical == 't'
-                                || t_logical == 'T'
-                                || t_logical == 't')
-                            {
-                                recordObjects[i] = true;
-                            }
-                            else if (t_logical == DBFFieldType.UnknownByte)
-                            {
-                                recordObjects[i] = DBNull.Value;
-                            }else
-                            {
-                                recordObjects[i] = false;
-                            }
-                            break;
-
                         case NativeDbType.Memo:
-                            if(string.IsNullOrEmpty(_dataMemoLoc))
-                                throw new Exception("Memo Location Not Set");
-
-
-                            var tRawMemoPointer = _dataInputStream.ReadBytes(_header.FieldArray[i].FieldLength);
-                            var tMemoPoiner = CharEncoding.GetString(tRawMemoPointer);
-                            if(string.IsNullOrEmpty(tMemoPoiner))
                             {
-                                recordObjects[i] = DBNull.Value;
+                                if (string.IsNullOrEmpty(_dataMemoLoc))
+                                    throw new Exception("Memo Location Not Set");
+
+                                byte[] tRawMemoPointer = _dataInputStream.ReadBytes(_header.FieldArray[i].FieldLength);
+                                string tMemoPoiner = CharEncoding.GetString(tRawMemoPointer);
+                                if (string.IsNullOrEmpty(tMemoPoiner))
+                                {
+                                    recordObjects[i] = DBNull.Value;
+                                    break;
+                                }
+                                long tBlock;
+                                if (!long.TryParse(tMemoPoiner, out tBlock))
+                                {
+                                    //Because Memo files can vary and are often the least importat data, 
+                                    //we will return null when it doesn't match our format.
+                                    recordObjects[i] = DBNull.Value;
+                                    break;
+                                }
+
+                                recordObjects[i] = new MemoValue(tBlock, this, _dataMemoLoc);
                                 break;
                             }
-                            long tBlock;
-                            if(!long.TryParse(tMemoPoiner, out tBlock))
-                            {  //Because Memo files can vary and are often the least importat data, 
-                                //we will return null when it doesn't match our format.
-                                recordObjects[i] = DBNull.Value;
-                                break;
-                            }
-
-
-                            recordObjects[i] = new MemoValue(tBlock, this, _dataMemoLoc);
-                            break;
                         default:
-                            _dataInputStream.ReadBytes(_header.FieldArray[i].FieldLength);
-                            recordObjects[i] = DBNull.Value;
-                            break;
+                            {
+                                _dataInputStream.ReadBytes(_header.FieldArray[i].FieldLength);
+                                recordObjects[i] = DBNull.Value;
+                                break;
+                            }
                     }
 
-                 
+
                 }
             }
             catch (EndOfStreamException)
@@ -426,6 +406,23 @@ namespace DotNetDBF
             }
 
             return selectIndexes.Any() ? selectIndexes.Select(it => recordObjects[it]).ToArray() : recordObjects;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0}/{1}/{2}", _header.Year, _header.Month, _header.Day);
+            sb.AppendLine();
+            sb.AppendFormat("Total records: {0}", _header.NumberOfRecords);
+            sb.AppendLine();
+            sb.AppendFormat("Header length: " + _header.HeaderLength);
+
+            for (int i = 0; i < _header.FieldArray.Length; i++)
+            {
+                sb.AppendLine(_header.FieldArray[i].Name);
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/DotNetDBF/DBFWriter.cs
+++ b/DotNetDBF/DBFWriter.cs
@@ -97,7 +97,7 @@ namespace DotNetDBF
             recordCount = header.NumberOfRecords;
         }
 
-        public byte Signature
+        public DBFSignature Signature
         {
             get
             {

--- a/DotNetDBF/MemoValue.cs
+++ b/DotNetDBF/MemoValue.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -7,93 +6,40 @@ namespace DotNetDBF
 {
     public class MemoValue
     {
-
+        #region Fields
         public const string MemoTerminator = "\x1A";
-        private bool _loaded;
-        private bool _new;
-        
-        
-
-        public MemoValue(string aValue)
-        {
-            _lockName = string.Format("DotNetDBF.Memo.new.{0}", Guid.NewGuid());
-            Value = aValue;
-         
-        }
-
-
-        internal MemoValue(long block, DBFBase aBase, string fileLoc)
-        {
-            _block = block;
-            _base = aBase;
-            _fileLoc = fileLoc;
-            _lockName = string.Format("DotNetDBF.Memo.read.{0}.{1}.", _fileLoc, _block);
-        }
 
         private readonly DBFBase _base;
         private readonly string _lockName;
-        private long _block;
         private readonly string _fileLoc;
-        private string _value;
 
+        private bool _loaded;
+        private bool _new;
+        private long _block;
+        private string _value;
+        #endregion
+
+        #region Consructor
+        public MemoValue(string memoValue)
+        {
+            _lockName = string.Format("DotNetDBF.Memo.new.{0}", Guid.NewGuid());
+            Value = memoValue;
+        }
+
+        internal MemoValue(long block, DBFBase dbfBase, string fileLoc)
+        {
+            _block = block;
+            _base = dbfBase;
+            _fileLoc = fileLoc;
+            _lockName = string.Format("DotNetDBF.Memo.read.{0}.{1}.", _fileLoc, _block);
+        }
+        #endregion
+
+        #region Properties
         internal long Block
         {
-            get
-            {
-               return _block;
-            }
+            get { return _block; }
         }
-
-        internal void Write(DBFWriter aBase)
-        {
-            lock (_lockName)
-            {
-                if (!_new)
-                    return;
-                if (string.IsNullOrEmpty(aBase.DataMemoLoc))
-                    throw new Exception("No Memo Location Set");
-
-                var raf =
-                    File.Open(aBase.DataMemoLoc,
-                              FileMode.OpenOrCreate,
-                              FileAccess.ReadWrite);
-
-                /* before proceeding check whether the passed in File object
-                    is an empty/non-existent file or not.
-                    */
-             
-
-                using (var tWriter = new BinaryWriter(raf, aBase.CharEncoding))
-                {
-                    if (raf.Length == 0)
-                    {
-                        var tHeader = new DBTHeader();
-                        tHeader.Write(tWriter);
-                    }
-
-                    var tValue = _value;
-                    if ((tValue.Length + sizeof(int)) % aBase.BlockSize != 0)
-                    {
-                        tValue = tValue + MemoTerminator;
-                    }
-
-                    var tPosition = raf.Seek(0, SeekOrigin.End); //Got To End Of File
-                    var tBlockDiff = tPosition%aBase.BlockSize;
-                    if (tBlockDiff != 0)
-                    {
-                        tPosition = raf.Seek(aBase.BlockSize - tBlockDiff, SeekOrigin.Current);
-                    }
-                    _block = tPosition/aBase.BlockSize;
-                    var tData = aBase.CharEncoding.GetBytes(tValue);
-                    var tDataLength = tData.Length;
-                    var tNewDiff = (tDataLength%aBase.BlockSize);
-                    tWriter.Write(tData);
-                    if (tNewDiff != 0)
-                        tWriter.Seek(aBase.BlockSize - (tDataLength % aBase.BlockSize), SeekOrigin.Current);
-                }
-            }
-        }
-
 
         public string Value
         {
@@ -101,48 +47,90 @@ namespace DotNetDBF
             {
                 lock (_lockName)
                 {
-                 
                     if (!_new && !_loaded)
                     {
-                        using (var reader =new BinaryReader(
-                            File.Open(_fileLoc, 
-                            FileMode.Open, 
-                            FileAccess.Read,
-                            FileShare.Read)))
+                        using (BinaryReader reader = new BinaryReader(File.Open(_fileLoc, FileMode.Open, FileAccess.Read, FileShare.Read)))
                         {
-                            reader.BaseStream.Seek(_block*_base.BlockSize, SeekOrigin.Begin);
-                            string tString;
-                            var tStringBuilder = new StringBuilder();
-                            int tIndex;
-                            var tSoftReturn = _base.CharEncoding.GetString(new byte[] {0x8d, 0x0a});
+                            reader.BaseStream.Seek(_block * _base.BlockSize, SeekOrigin.Begin);
+                            string tempString;
+                            StringBuilder sb = new StringBuilder();
+                            int index;
+                            string softReturn = _base.CharEncoding.GetString(new byte[] { 0x8d, 0x0a });
 
                             do
                             {
-                                var tData = reader.ReadBytes(_base.BlockSize);
-                               
-                                tString = _base.CharEncoding.GetString(tData);
-                                tIndex = tString.IndexOf(MemoTerminator);
-                                if (tIndex != -1)
-                                    tString = tString.Substring(0, tIndex);
-                                tStringBuilder.Append(tString);
-                            } while (tIndex == -1);
-                            _value = tStringBuilder.ToString().Replace(tSoftReturn,String.Empty);
+                                byte[] data = reader.ReadBytes(_base.BlockSize);
+
+                                tempString = _base.CharEncoding.GetString(data);
+                                index = tempString.IndexOf(MemoTerminator);
+                                if (index != -1)
+                                    tempString = tempString.Substring(0, index);
+                                sb.Append(tempString);
+                            } while (index == -1);
+
+                            sb.Replace(softReturn, String.Empty);
+                            _value = sb.ToString();
                         }
                         _loaded = true;
                     }
 
                     return _value;
                 }
-            }set
+            }
+            set
             {
                 lock (_lockName)
                 {
                     _new = true;
-
-                   
                     _value = value;
                 }
 
+            }
+        }
+        #endregion
+
+        internal void Write(DBFWriter dbfWriter)
+        {
+            lock (_lockName)
+            {
+                if (!_new)
+                    return;
+                if (string.IsNullOrEmpty(dbfWriter.DataMemoLoc))
+                    throw new Exception("No Memo Location Set");
+
+                FileStream fs = File.Open(dbfWriter.DataMemoLoc, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+
+                // before proceeding check whether the passed in File object
+                // is an empty/non-existent file or not.
+
+                using (BinaryWriter writer = new BinaryWriter(fs, dbfWriter.CharEncoding))
+                {
+                    if (fs.Length == 0)
+                    {
+                        DBTHeader header = new DBTHeader();
+                        header.Write(writer);
+                    }
+
+                    var tValue = _value;
+                    if ((tValue.Length + sizeof(int)) % dbfWriter.BlockSize != 0)
+                    {
+                        tValue = tValue + MemoTerminator;
+                    }
+
+                    long position = fs.Seek(0, SeekOrigin.End); // Got to end of file
+                    long blockDiff = position % dbfWriter.BlockSize;
+                    if (blockDiff != 0)
+                    {
+                        position = fs.Seek(dbfWriter.BlockSize - blockDiff, SeekOrigin.Current);
+                    }
+                    _block = position/dbfWriter.BlockSize;
+                    byte[] data = dbfWriter.CharEncoding.GetBytes(tValue);
+                    int dataLength = data.Length;
+                    int newDiff = (dataLength % dbfWriter.BlockSize);
+                    writer.Write(data);
+                    if (newDiff != 0)
+                        writer.Seek(dbfWriter.BlockSize - (dataLength % dbfWriter.BlockSize), SeekOrigin.Current);
+                }
             }
         }
 
@@ -150,18 +138,19 @@ namespace DotNetDBF
         {
             return _lockName.GetHashCode();
         }
+
         public override string ToString()
         {
             return Value;
         } 
+
         public override bool Equals(object obj)
         {
-            if(obj as MemoValue == null)
+            if (obj as MemoValue == null)
                 return false;
-            if(ReferenceEquals(this,obj))
-            {
+            if (ReferenceEquals(this, obj))
                 return true;
-            }
+
             return Value.Equals(((MemoValue)obj).Value);
         }
     }

--- a/DotNetDBF/Utils.cs
+++ b/DotNetDBF/Utils.cs
@@ -17,17 +17,18 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using System.Threading;
 
 namespace DotNetDBF
 {
-    static public class Utils
+    /// <summary>
+    /// Static class that contains utility functions.
+    /// </summary>
+    public static class Utils
     {
-
         public const int ALIGN_LEFT = 10;
         public const int ALIGN_RIGHT = 12;
 
-        static public byte[] FillArray(byte[] anArray, byte value)
+        public static byte[] FillArray(byte[] anArray, byte value)
         {
             for (int i = 0; i < anArray.Length; i++)
             {
@@ -36,93 +37,64 @@ namespace DotNetDBF
             return anArray;
         }
 
-        static public byte[] trimLeftSpaces(byte[] arr)
+        public static byte[] trimLeftSpaces(byte[] array)
         {
-            List<byte> tList = new List<byte>(arr.Length);
+            List<byte> list = new List<byte>(array.Length);
 
-            for (int i = 0; i < arr.Length; i++)
+            for (int i = 0; i < array.Length; i++)
             {
-                if (arr[i] != ' ')
+                if (array[i] != ' ')
                 {
-                    tList.Add(arr[i]);
+                    list.Add(array[i]);
                 }
             }
-            return tList.ToArray();
+            return list.ToArray();
         }
 
-        static public byte[] textPadding(String text,
-                                         Encoding charEncoding,
-                                         int length)
+        public static byte[] textPadding(String text, Encoding charEncoding, int length)
         {
             return textPadding(text, charEncoding, length, ALIGN_LEFT);
         }
 
-        static public byte[] textPadding(String text,
-                                         Encoding charEncoding,
-                                         int length,
-                                         int alignment)
+        public static byte[] textPadding(String text, Encoding charEncoding, int length, int alignment)
         {
-            return
-                textPadding(text,
-                            charEncoding,
-                            length,
-                            alignment,
-                            DBFFieldType.Space);
+            return textPadding(text, charEncoding, length, alignment, DBFFieldType.Space);
         }
 
-        static public byte[] textPadding(String text,
-                                         Encoding charEncoding,
-                                         int length,
-                                         int alignment,
-                                         byte paddingByte)
+        public static byte[] textPadding(String text, Encoding charEncoding, int length, int alignment, byte paddingByte)
         {
-            Encoding tEncoding = charEncoding;
-            var inputBytes = tEncoding.GetBytes(text);
+            Encoding encoding = charEncoding;
+            var inputBytes = encoding.GetBytes(text);
             if (inputBytes.Length >= length)
             {
                 return inputBytes.Take(length).ToArray();
             }
 
-            byte[] byte_array = FillArray(new byte[length], paddingByte);
+            byte[] array = FillArray(new byte[length], paddingByte);
 
             switch (alignment)
             {
                 case ALIGN_LEFT:
-                    Array.Copy(inputBytes,
-                               0,
-                               byte_array,
-                               0,
-                               inputBytes.Length);
+                    Array.Copy(inputBytes, 0, array, 0, inputBytes.Length);
                     break;
-
                 case ALIGN_RIGHT:
-                    int t_offset = length - text.Length;
-                    Array.Copy(inputBytes,
-                               0,
-                               byte_array,
-                               t_offset,
-                               inputBytes.Length);
+                    int offset = length - text.Length;
+                    Array.Copy(inputBytes, 0, array, offset, inputBytes.Length);
                     break;
             }
 
-            return byte_array;
+            return array;
         }
 
-        static public byte[] NumericFormating(IFormattable doubleNum,
-                                              Encoding charEncoding,
-                                              int fieldLength,
-                                              int sizeDecimalPart)
+        public static byte[] NumericFormating(IFormattable doubleNum, Encoding charEncoding, int fieldLength, int sizeDecimalPart)
         {
-            int sizeWholePart = fieldLength
-                                -
-                                (sizeDecimalPart > 0 ? (sizeDecimalPart + 1) : 0);
+            int sizeWholePart = fieldLength - (sizeDecimalPart > 0 ? (sizeDecimalPart + 1) : 0);
 
             StringBuilder format = new StringBuilder(fieldLength);
 
             for (int i = 0; i < sizeWholePart; i++)
             {
-
-                format.Append(i+1== sizeWholePart ? "0":"#");
+                format.Append(i + 1 == sizeWholePart ? "0" : "#");
             }
 
             if (sizeDecimalPart > 0)
@@ -134,26 +106,15 @@ namespace DotNetDBF
                     format.Append("0");
                 }
             }
-
-
-            return
-                textPadding(
-                    doubleNum.ToString(format.ToString(),
-                                       NumberFormatInfo.InvariantInfo),
-                    charEncoding,
-                    fieldLength,
-                    ALIGN_RIGHT);
+            return textPadding(doubleNum.ToString(format.ToString(), NumberFormatInfo.InvariantInfo), charEncoding, fieldLength, ALIGN_RIGHT);
         }
 
-        static public bool contains(byte[] arr, byte value)
+        public static bool contains(byte[] array, byte value)
         {
-            return
-                Array.Exists(arr,
-                             delegate(byte anItem) { return anItem == value; });
+            return Array.Exists(array, item => item == value);
         }
 
-
-        static public Type TypeForNativeDBType(NativeDbType aType)
+        public static Type TypeForNativeDBType(NativeDbType aType)
         {
             switch(aType)
             {
@@ -170,7 +131,7 @@ namespace DotNetDBF
                 case NativeDbType.Memo:
                     return typeof (MemoValue);
                 default:
-                    throw new ArgumentException("Unsupported Type");
+                    throw new ArgumentException("Unsupported type.");
             }
         }
     }


### PR DESCRIPTION
Added property `NumberFormatProvider` (of type `NumberFormatInfo`) to `DBFBase `class. This property must be set in order to floating point numbers be parsed correctly without throwing an exception.

Converted some of java comments to C# XML comments.
Also some of code refactoring and renaming done to follow C# convention.