### PR TITLE
NullSymbol - ability to customize null-value behavior in DbfWriter.

### DIFF
--- a/DotNetDBF/DBFReader.cs
+++ b/DotNetDBF/DBFReader.cs
@@ -31,6 +31,7 @@ namespace DotNetDBF
         private int[] _orderedSelectFields = new int[] {};
         /* Class specific variables */
         private bool _isClosed = true;
+        private string _nullSymbol;
 
         /**
 		 Initializes a DBFReader object.
@@ -161,6 +162,17 @@ namespace DotNetDBF
         }
 #endif
 
+	public string NullSymbol
+        {
+            get { return _nullSymbol ?? DBFFieldType.Unknown; }
+            set
+            {
+                if (value != null && value.Length != 1)
+                    throw new ArgumentException(nameof(NullSymbol));
+                _nullSymbol = value;
+            }
+        }
+	
         public delegate Stream LazyStream();
 
         private Stream _loadedStream;
@@ -349,7 +361,7 @@ namespace DotNetDBF
                                 var tLast = tParsed.Substring(tParsed.Length - 1);
                                 if (tParsed.Length > 0
                                     && tLast != " "
-                                    && tLast != DBFFieldType.Unknown)
+                                    && tLast != NullSymbol)
                                 {
                                     recordObjects[i] = Double.Parse(tParsed,
                                         NumberStyles.Float | NumberStyles.AllowLeadingWhite,
@@ -383,7 +395,7 @@ namespace DotNetDBF
                                 var tLast = tParsed.Substring(tParsed.Length - 1);
                                 if (tParsed.Length > 0
                                     && tLast != " "
-                                    && tLast != DBFFieldType.Unknown)
+                                    && tLast != NullSymbol)
                                 {
                                     recordObjects[i] = Decimal.Parse(tParsed,
                                         NumberStyles.Float | NumberStyles.AllowLeadingWhite,

--- a/DotNetDBF/DBFWriter.cs
+++ b/DotNetDBF/DBFWriter.cs
@@ -151,7 +151,7 @@ namespace DotNetDBF
             get { return _nullSymbol; }
             set
             {
-                if (value.Length != 1)
+                if (value != null && value.Length != 1)
                     throw new ArgumentException(nameof(NullSymbol));
                 _nullSymbol = value;
             }

--- a/DotNetDBF/DBFWriter.cs
+++ b/DotNetDBF/DBFWriter.cs
@@ -27,6 +27,7 @@ namespace DotNetDBF
         private List<object> v_records = new List<object>();
         private string _dataMemoLoc;
         private Stream _dataMemo;
+	private string _nullSymbol;
 
         /// Creates an empty Object.
         public DBFWriter()
@@ -145,6 +146,16 @@ namespace DotNetDBF
             }
         }
 
+	public string NullSymbol
+        {
+            get { return _nullSymbol; }
+            set
+            {
+                if (value.Length != 1)
+                    throw new ArgumentException(nameof(NullSymbol));
+                _nullSymbol = value;
+            }
+        }
 
         public DBFField[] Fields
         {
@@ -447,7 +458,7 @@ namespace DotNetDBF
                         {
                             dataOutput.Write(
                                 Utils.textPadding(
-                                    DBFFieldType.Unknown,
+                                    NullSymbol ?? DBFFieldType.Unknown,
                                     CharEncoding,
                                     header.FieldArray[j].FieldLength,
                                     Utils.ALIGN_RIGHT
@@ -475,7 +486,7 @@ namespace DotNetDBF
                         {
                             dataOutput.Write(
                                 Utils.textPadding(
-                                    DBFFieldType.Unknown,
+                                    NullSymbol ?? DBFFieldType.Unknown,
                                     CharEncoding,
                                     header.FieldArray[j].FieldLength,
                                     Utils.ALIGN_RIGHT

--- a/DotNetDBF/DBFWriter.cs
+++ b/DotNetDBF/DBFWriter.cs
@@ -27,7 +27,7 @@ namespace DotNetDBF
         private List<object> v_records = new List<object>();
         private string _dataMemoLoc;
         private Stream _dataMemo;
-	private string _nullSymbol;
+        private string _nullSymbol;
 
         /// Creates an empty Object.
         public DBFWriter()

--- a/DotNetDBF/DBFWriter.cs
+++ b/DotNetDBF/DBFWriter.cs
@@ -148,7 +148,7 @@ namespace DotNetDBF
 
 	public string NullSymbol
         {
-            get { return _nullSymbol; }
+            get { return _nullSymbol ?? DBFFieldType.Unknown; }
             set
             {
                 if (value != null && value.Length != 1)
@@ -458,7 +458,7 @@ namespace DotNetDBF
                         {
                             dataOutput.Write(
                                 Utils.textPadding(
-                                    NullSymbol ?? DBFFieldType.Unknown,
+                                    NullSymbol,
                                     CharEncoding,
                                     header.FieldArray[j].FieldLength,
                                     Utils.ALIGN_RIGHT
@@ -486,7 +486,7 @@ namespace DotNetDBF
                         {
                             dataOutput.Write(
                                 Utils.textPadding(
-                                    NullSymbol ?? DBFFieldType.Unknown,
+                                    NullSymbol,
                                     CharEncoding,
                                     header.FieldArray[j].FieldLength,
                                     Utils.ALIGN_RIGHT


### PR DESCRIPTION
In DBF there is no strict specification about null fields of numeric types. Sometimes empty string is used for this, sometimes `?`. Some readers think that `?` is equal to 0.0 what is wrong. I need to put empty string to make them work correctly. In my case I need to control it, so I propose special property for this. 