### PR TITLE
Change the .NET data type used for FoxPro float data type to decimal

### DIFF
--- a/DotNetDBF/DBFReader.cs
+++ b/DotNetDBF/DBFReader.cs
@@ -355,7 +355,13 @@ namespace DotNetDBF
                                     && tLast != " "
                                     && tLast != NullSymbol)
                                 {
-                                    recordObjects[i] = double.Parse(tParsed,
+                                    //
+                                    // A Float in FoxPro has 20 significant digits, since it is
+                                    // stored as a string with possible E-postfix notation.
+                                    // An IEEE 754 float or double can not handle this number of digits
+                                    // correctly. Therefor the only correct implementation is to use a decimal.
+                                    //
+                                    recordObjects[i] = decimal.Parse(tParsed,
                                         NumberStyles.Float | NumberStyles.AllowLeadingWhite,
                                         NumberFormatInfo.InvariantInfo);
                                 }

--- a/DotNetDBF/DBFWriter.cs
+++ b/DotNetDBF/DBFWriter.cs
@@ -443,7 +443,7 @@ namespace DotNetDBF
 
                         if (objectArray[j] != null && objectArray[j] != DBNull.Value)
                         {
-                            var tDouble = Convert.ToDouble(objectArray[j]);
+                            var tDouble = Convert.ToDecimal(objectArray[j]);
                             dataOutput.Write(
                                 Utils.NumericFormating(
                                     tDouble,

--- a/DotNetDBF/DotNetDBF.csproj
+++ b/DotNetDBF/DotNetDBF.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net35;netstandard1.3;netstandard2.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
-    <Version>6.0.0.3</Version>
+    <Version>7.0.0.0</Version>
     <Company>Ekon Benefits</Company>
     <Copyright>Copyright 2009-2017</Copyright>
     <Description>This is a basic file parser for reading and writing xBase DBF files particularlly Clipper. Code originally derived from javadbf.</Description>

--- a/DotNetDBF/Utils.cs
+++ b/DotNetDBF/Utils.cs
@@ -164,7 +164,7 @@ namespace DotNetDBF
                 case NativeDbType.Logical:
                     return typeof(bool);
                 case NativeDbType.Float:
-                    return typeof(float);
+                    return typeof(decimal);
                 case NativeDbType.Memo:
                     return typeof(MemoValue);
                 default:


### PR DESCRIPTION
We are experiencing some issues using the FoxPro double data type. It seems that this data type is not entirely compatible with the .NET Float and Double data type, which both derive from the IEEE 754 specification.

A Float in FoxPro has 20 significant digits, since it is stored as a string with possible E-postfix notation. An IEEE 754 float or double can not handle this number of digits correctly. To accommodate the lack of precision by .NET Float and Double, I propose to use Decimal instead.