### PR TITLE
Sometimes there is no Field Descriptor terminator 0x0D.

### DIFF
--- a/DotNetDBF/DBFHeader.cs
+++ b/DotNetDBF/DBFHeader.cs
@@ -132,7 +132,13 @@ namespace DotNetDBF
             while (field != null)
             {
                 v_fields.Add(field);
-                field = DBFField.CreateField(dataInput);
+
+                if ((HeaderLength - dataInput.BaseStream.Position) < 32)
+                {
+                    break;
+                }
+
+                field = DBFField.CreateField(dataInput);                
             }
 
             FieldArray = v_fields.ToArray();

--- a/DotNetDBF/DBFReader.cs
+++ b/DotNetDBF/DBFReader.cs
@@ -87,12 +87,10 @@ namespace DotNetDBF
                 _header.Read(_dataInputStream);
 
                 /* it might be required to leap to the start of records at times */
-                var t_dataStartIndex = _header.HeaderLength
-                                       - (32 + (32 * _header.FieldArray.Length))
-                                       - 1;
+                var t_dataStartIndex = _header.HeaderLength - _dataInputStream.BaseStream.Position;
                 if (t_dataStartIndex > 0)
                 {
-                    _dataInputStream.ReadBytes((t_dataStartIndex));
+                    _dataInputStream.ReadBytes((int)(t_dataStartIndex));
                 }
             }
             catch (IOException ex)


### PR DESCRIPTION
Use HeaderLength and dataInput.BaseStream.Position to determine whether there is a field and leap to the start of records.